### PR TITLE
Avoid .unwrap() which crashes the application on startup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -608,15 +608,20 @@ where
 
     match config.window_mode {
         WindowMode::Windowed(width, height) => {
-            let monitor = event_loop.primary_monitor().unwrap();
-            let size = monitor.size();
-            let position = PhysicalPosition::new(
-                (size.width - width) as i32 / 2,
-                (size.height - height) as i32 / 2,
-            );
+            //Set window size
             builder = builder
-                .with_inner_size(PhysicalSize::new(width, height))
-                .with_position(position);
+                .with_inner_size(PhysicalSize::new(width, height));
+
+            //If a primary monitor can be found, position the window in the middle
+            if let Some(monitor)=event_loop.primary_monitor(){
+                let size = monitor.size();
+                let position = PhysicalPosition::new(
+                    (size.width - width) as i32 / 2,
+                    (size.height - height) as i32 / 2,
+                );
+                builder = builder
+                    .with_position(position);
+            }
         }
         WindowMode::Fullscreen => {
             builder =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -609,23 +609,20 @@ where
     match config.window_mode {
         WindowMode::Windowed(width, height) => {
             //Set window size
-            builder = builder
-                .with_inner_size(PhysicalSize::new(width, height));
+            builder = builder.with_inner_size(PhysicalSize::new(width, height));
 
             //If a primary monitor can be found, position the window in the middle
-            if let Some(monitor)=event_loop.primary_monitor(){
+            if let Some(monitor) = event_loop.primary_monitor() {
                 let size = monitor.size();
                 let position = PhysicalPosition::new(
                     (size.width - width) as i32 / 2,
                     (size.height - height) as i32 / 2,
                 );
-                builder = builder
-                    .with_position(position);
+                builder = builder.with_position(position);
             }
         }
         WindowMode::Fullscreen => {
-            builder =
-                builder.with_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
+            builder = builder.with_fullscreen(Some(winit::window::Fullscreen::Borderless(None)));
         }
     }
 


### PR DESCRIPTION
Wayland doesn't have a primary monitor (for some reason), as can be seen in the primary_monitor function [documentation](https://docs.rs/winit/latest/winit/event_loop/struct.ActiveEventLoop.html#method.primary_monitor).  Thus, the application crashes.

Alternative to https://github.com/DeadlockCode/barnes-hut/pull/2